### PR TITLE
remove .png link in alert prefix for SE posts

### DIFF
--- a/hubotrssconfig.json
+++ b/hubotrssconfig.json
@@ -10,7 +10,7 @@
         },
         "room": "town square",
         "pingInterval": "60",
-        "alertPrefix": "![SE](https://civicrm.org/sites/civicrm.org/files/rss-stackexchange.png) ",
+        "alertPrefix": "",
         "alertSuffix": ""
     },
     {


### PR DESCRIPTION
a test to see if eliminating the .png link makes any difference in only random SE questions appearing in the ~town square channel at chat.civicrm.org , rather than all appearing, as they should....