### PR TITLE
Remove hubot-drupalorg

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "hubot": "^2.19.0",
     "hubot-bolts": "git+https://github.com/xurizaemon/hubot-bolts.git",
     "hubot-diagnostics": "0.0.1",
-    "hubot-drupalorg": "0.0.2",
     "hubot-factoids": "^1.2.0",
     "hubot-google-images": "^0.2.6",
     "hubot-google-translate": "^0.2.0",


### PR DESCRIPTION
This appears to be causing errors now and isn't widely used.